### PR TITLE
Experiment: pin Node to 24.14.1 in CI

### DIFF
--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -13,7 +13,9 @@ runs:
   steps:
     - uses: actions/setup-node@v6.3.0
       with:
-        node-version: 24
+        # Pinned to 24.14.1: Node 24.16.0 broke @electron/get's binary
+        # download (silent exit 0, no `path.txt`). Experiment to confirm.
+        node-version: 24.14.1
         cache: npm
 
     - name: Install dependencies

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,9 @@ jobs:
 
       - uses: actions/setup-node@v6.4.0
         with:
-          node-version: 24
+          # Pinned to 24.14.1: Node 24.16.0 broke @electron/get's binary
+          # download (silent exit 0, no `path.txt`). Experiment to confirm.
+          node-version: 24.14.1
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Pin `node-version: 24` → `24.14.1` in `.github/workflows/main.yaml` and `.github/actions/e2e/action.yaml`.
- Diagnostic experiment to confirm whether Node 24.16.0 (current `24` resolution) is what broke `@electron/get`'s binary download, silently making both `install.js` and `electron-forge package` exit 0 without producing the Electron binary.
- 24.14.1 is the version the last green main run (May 13) resolved to. Lockfile is unchanged between then and now, so Node version is the only obvious variable.

## Test plan
- [ ] CI passes on this PR → Node version was the cause. We'll then decide whether to keep the pin, file an upstream issue, or both.
- [ ] CI fails on this PR → Node is not the cause; we'll need to look at runner image or upstream service changes.