### PR TITLE
Experiment: pin Node to 24.15.0 (bisect)

### DIFF
--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -13,7 +13,8 @@ runs:
   steps:
     - uses: actions/setup-node@v6.3.0
       with:
-        node-version: 24
+        # Experiment: bisect which Node patch broke @electron/get.
+        node-version: 24.15.0
         cache: npm
 
     - name: Install dependencies

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,8 @@ jobs:
 
       - uses: actions/setup-node@v6.4.0
         with:
-          node-version: 24
+          # Experiment: bisect which Node patch broke @electron/get.
+          node-version: 24.15.0
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
Bisection step 2 — narrowing which Node patch broke `@electron/get`. If this passes too, the regression is in 24.16.0 (likely [nodejs/node#63082](https://github.com/nodejs/node/pull/63082)). If it fails, the regression is in 24.15.0.

Companion to #365 (which pins 24.14.1 and passed).